### PR TITLE
fix: replace ValueError with AuthenticationFailed

### DIFF
--- a/id_broker/account/views.py
+++ b/id_broker/account/views.py
@@ -54,18 +54,15 @@ class IDRegister(GenericViewSet, CreateModelMixin):
         ):
             raise ValidationError({"email": ["This email was registered; please use forgot password to reset it."]})
 
-        user_draft = UserDraft(**validated_data)
-        user_draft.username = validated_data["email"]
-        user_draft.set_password(validated_data["password"])
-        user_draft.save()
-
         user_profile = UserProfile(
             id_provider=helper.BUILTIN_USER_POOL,
-            preferred_name="{first_name} {last_name}".format(**validated_data),
+            preferred_name="{first_name} {last_name}".format(**validated_data).strip(),
         )
-        user_draft.user_profile = user_profile
-
         user_profile.save()
+
+        user_draft = UserDraft(user_profile=user_profile, **validated_data)
+        user_draft.username = validated_data["email"]
+        user_draft.set_password(validated_data["password"])
         user_draft.save()
 
         activate_token = default_token_generator.make_token(user_draft)

--- a/id_broker/security/serializers.py
+++ b/id_broker/security/serializers.py
@@ -20,6 +20,6 @@ class ActivatePasswordResetSerializer(serializers.ModelSerializer):
 
 
 class PerformPasswordResetSerializer(serializers.Serializer):
-    verification_code = serializers.CharField()
-    reset_token = serializers.CharField()
+    verification_code = serializers.CharField(max_length=12, min_length=1)
+    reset_token = serializers.CharField(max_length=50, min_length=1)
     new_password = serializers.CharField(max_length=50, min_length=6)

--- a/id_broker/security/views.py
+++ b/id_broker/security/views.py
@@ -132,10 +132,10 @@ class PerformPasswordResetViews(GenericViewSet, UpdateModelMixin):
         try:
             user_pk = helper.base36_to_pk(verification_code)
         except ValueError:
-            raise ValueError("Invalid activate_token or verification_code")
+            raise AuthenticationFailed("Invalid reset_token or verification_code")
 
         if not 0 < user_pk < helper.MAX_PK_NUMBER:
-            raise ValueError("Invalid activate_token or verification_code")
+            raise AuthenticationFailed("Invalid reset_token or verification_code")
 
         try:
             user: User = User.objects.select_related("user_profile").get(pk=user_pk)


### PR DESCRIPTION
addresses issue with the `raise-exception` feature by substituting instances of `ValueError` with the more appropriate `AuthenticationFailed` in the /security/perform-password-reset module.